### PR TITLE
Fix memory leaks.

### DIFF
--- a/src/mdlComponentHandler.js
+++ b/src/mdlComponentHandler.js
@@ -87,9 +87,6 @@ componentHandler = (function() {
   /** @type {!Array<componentHandler.ComponentConfig>} */
   var registeredComponents_ = [];
 
-  /** @type {!Array<componentHandler.Component>} */
-  var createdComponents_ = [];
-
   var componentConfigProperty_ = 'mdlComponentConfigInternal_';
 
   /**
@@ -239,7 +236,6 @@ componentHandler = (function() {
         element.setAttribute('data-upgraded', upgradedList.join(','));
         var instance = new registeredClass.classConstructor(element);
         instance[componentConfigProperty_] = registeredClass;
-        createdComponents_.push(instance);
         // Call any callbacks the user has registered with this component type.
         for (var j = 0, m = registeredClass.callbacks.length; j < m; j++) {
           registeredClass.callbacks[j](element);
@@ -361,52 +357,9 @@ componentHandler = (function() {
   }
 
   /**
-   * Check the component for the downgrade method.
-   * Execute if found.
-   * Remove component from createdComponents list.
-   *
-   * @param {?componentHandler.Component} component
+   * fake deconstructor
    */
-  function deconstructComponentInternal(component) {
-    if (component) {
-      var componentIndex = createdComponents_.indexOf(component);
-      createdComponents_.splice(componentIndex, 1);
-
-      var upgrades = component.element_.getAttribute('data-upgraded').split(',');
-      var componentPlace = upgrades.indexOf(component[componentConfigProperty_].classAsString);
-      upgrades.splice(componentPlace, 1);
-      component.element_.setAttribute('data-upgraded', upgrades.join(','));
-
-      var ev = createEvent_('mdl-componentdowngraded', true, false);
-      component.element_.dispatchEvent(ev);
-    }
-  }
-
-  /**
-   * Downgrade either a given node, an array of nodes, or a NodeList.
-   *
-   * @param {!Node|!Array<!Node>|!NodeList} nodes
-   */
-  function downgradeNodesInternal(nodes) {
-    /**
-     * Auxiliary function to downgrade a single node.
-     * @param  {!Node} node the node to be downgraded
-     */
-    var downgradeNode = function(node) {
-      createdComponents_.filter(function(item) {
-        return item.element_ === node;
-      }).forEach(deconstructComponentInternal);
-    };
-    if (nodes instanceof Array || nodes instanceof NodeList) {
-      for (var n = 0; n < nodes.length; n++) {
-        downgradeNode(nodes[n]);
-      }
-    } else if (nodes instanceof Node) {
-      downgradeNode(nodes);
-    } else {
-      throw new Error('Invalid argument provided to downgrade MDL nodes.');
-    }
-  }
+  function fakeDowngradeElements() {}
 
   // Now return the functions that should be made public with their publicly
   // facing names...
@@ -417,7 +370,7 @@ componentHandler = (function() {
     upgradeAllRegistered: upgradeAllRegisteredInternal,
     registerUpgradedCallback: registerUpgradedCallbackInternal,
     register: registerInternal,
-    downgradeElements: downgradeNodesInternal
+    downgradeElements: fakeDowngradeElements,
   };
 })();
 

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -102,6 +102,8 @@
     }
 
     this.element_.classList.add(this.CssClasses_.IS_ACTIVE);
+    window.addEventListener('scroll', this.boundMouseLeaveAndScrollHandler, true);
+    window.addEventListener('touchstart', this.boundMouseLeaveAndScrollHandler);
   };
 
   /**
@@ -111,6 +113,8 @@
    */
   MaterialTooltip.prototype.hideTooltip_ = function() {
     this.element_.classList.remove(this.CssClasses_.IS_ACTIVE);
+    window.removeEventListener('scroll', this.boundMouseLeaveAndScrollHandler, true);
+    window.removeEventListener('touchstart', this.boundMouseLeaveAndScrollHandler);
   };
 
   /**
@@ -137,8 +141,6 @@
         this.forElement_.addEventListener('mouseenter', this.boundMouseEnterHandler, false);
         this.forElement_.addEventListener('touchend', this.boundMouseEnterHandler, false);
         this.forElement_.addEventListener('mouseleave', this.boundMouseLeaveAndScrollHandler, false);
-        window.addEventListener('scroll', this.boundMouseLeaveAndScrollHandler, true);
-        window.addEventListener('touchstart', this.boundMouseLeaveAndScrollHandler);
       }
     }
   };

--- a/test/unit/componentHandler.js
+++ b/test/unit/componentHandler.js
@@ -178,13 +178,4 @@ describe('componentHandler', function() {
       expect($(buttons[i])).to.have.data('upgraded', ',MaterialButton');
     }
   });
-
-  it('should downgrade multiple components at once', function() {
-    var button = document.createElement('button');
-    button.className = 'mdl-button mdl-js-button mdl-js-ripple-effect';
-    componentHandler.upgradeElement(button);
-    expect(button.dataset.upgraded).to.equal(',MaterialButton,MaterialRipple');
-    componentHandler.downgradeElements(button);
-    expect(button.dataset.upgraded).to.equal('');
-  });
 });


### PR DESCRIPTION
- Remove event handlers from `window` when the tooltip is not showing.
- Get rid of component deconstruction remnants.

`downgradeElements` was updated in dec 2015 to not actually do any downgrading, because at the time none of the components needed deconstruction. A memory leak was then added to the Tooltip component in May 2016.

These changes to `downgradeElements` were problematic:
 - It still removes the `data-upgraded` attributes from dom elements, even though no deconstruction actually happened. This means that calling `upgradElement` again will double-upgrade the element.
 - the `createComponents_` array no longer serves any purpose.